### PR TITLE
feat(frontend-auth): Nuxt 脚手架 + OpenIddict Abp_Vue 客户端 + CORS & 前端 Secrets

### DIFF
--- a/doc/08_配置管理/Secrets管理.md
+++ b/doc/08_配置管理/Secrets管理.md
@@ -37,6 +37,20 @@ dotnet user-secrets set "Db:Password" "DevPassword123!"
 | BH_DB_PASSWORD | Postgres 密码（可选） | 同上 |
 | BH_OTEL_EXPORTER_OTLP_ENDPOINT | OTLP Collector 端点 | 统一采集日志/Trace/指标 |
 
+### 前端 (Nuxt / ABP Vue) 相关环境变量
+
+| 变量名 | 用途 | 说明 | 是否敏感 |
+|--------|------|------|----------|
+| NUXT_AUTHORITY_URL | OIDC 授权服务器地址 | 指向后端 OpenIddict Host (HTTPS) | 否 |
+| NUXT_CLIENT_ID | 前端 OIDC ClientId | 需与数据种子中 Abp_Vue 匹配 | 否 |
+| NUXT_CLIENT_SECRET | OIDC ClientSecret | 若客户端机密型才需要 | 是 |
+| NUXT_SCOPE | 请求的 Scope 列表 | openid profile email BilliardHall 等 | 否 |
+| NUXT_REDIRECT_URI | 登录回调相对路径 | /api/auth/callback/openiddict | 否 |
+| NUXT_POST_LOGOUT_REDIRECT_URI | 登出回调路径 | /api/auth/signout/callback | 否 |
+| NUXT_ORIGIN | 前端站点完整基址 | <https://localhost:3000> | 否 |
+| NUXT_SESSION_SECRET | 前端 Session 加密种子 | 随机生成 Base64 | 是 |
+| NUXT_ABP_API_ENDPOINT | 后端 API 根地址 | <https://localhost:44388/api> | 否 |
+
 ## 生产环境策略
 
 1. 使用云 Secret 管理服务（Azure Key Vault / AWS Secrets Manager / HashiCorp Vault）。

--- a/src/Zss.BilliardHall/src/Zss.BilliardHall.Domain/OpenIddict/OpenIddictDataSeedContributor.cs
+++ b/src/Zss.BilliardHall/src/Zss.BilliardHall.Domain/OpenIddict/OpenIddictDataSeedContributor.cs
@@ -111,8 +111,44 @@ public class OpenIddictDataSeedContributor : IDataSeedContributor, ITransientDep
                 logoUri: "/images/clients/angular.svg"
             );
         }
+        // Vue 前端客户端（Abp_Vue）如果在配置中声明则自动创建
+        var vueClientId = configurationSection["Abp_Vue:ClientId"]; // e.g. Abp_Vue
+        if (!vueClientId.IsNullOrWhiteSpace())
+        {
+            var vueRoot = configurationSection["Abp_Vue:RootUrl"]?.TrimEnd('/'); // e.g. https://localhost:3000
+            var vueSecret = configurationSection["Abp_Vue:ClientSecret"]; // 可为空(公共)或有值(机密)
 
-        
+            var redirectUris = new List<string>
+            {
+                $"{vueRoot}/api/auth/callback/openiddict"
+            };
+            var postLogoutUris = new List<string>
+            {
+                $"{vueRoot}/api/auth/signout/callback"
+            };
+
+            // 若配置了 Secret 则视为 Confidential，否则 Public
+            var clientType = vueSecret.IsNullOrWhiteSpace() ? OpenIddictConstants.ClientTypes.Public : OpenIddictConstants.ClientTypes.Confidential;
+
+            await CreateApplicationAsync(
+                applicationType: OpenIddictConstants.ApplicationTypes.Web,
+                name: vueClientId!,
+                type: clientType,
+                consentType: OpenIddictConstants.ConsentTypes.Implicit,
+                displayName: "ABP Vue Frontend",
+                secret: vueSecret,
+                grantTypes: new List<string>
+                {
+                    OpenIddictConstants.GrantTypes.AuthorizationCode,
+                    OpenIddictConstants.GrantTypes.RefreshToken
+                },
+                scopes: commonScopes,
+                redirectUris: redirectUris,
+                postLogoutRedirectUris: postLogoutUris,
+                clientUri: vueRoot,
+                logoUri: "/images/clients/vue.svg"
+            );
+        }
         
 
 

--- a/src/Zss.BilliardHall/src/Zss.BilliardHall.HttpApi.Host/BilliardHallHttpApiHostModule.cs
+++ b/src/Zss.BilliardHall/src/Zss.BilliardHall.HttpApi.Host/BilliardHallHttpApiHostModule.cs
@@ -206,6 +206,7 @@ public class BilliardHallHttpApiHostModule : AbpModule
         {
             options.AddDefaultPolicy(builder =>
             {
+                // App:CorsOrigins 在 appsettings.* 中以逗号分隔。当前开发环境增加了 https://localhost:3000 以支持 Vue/Nuxt 前端 OIDC 登录与 API 调用。
                 builder
                     .WithOrigins(
                         configuration["App:CorsOrigins"]?

--- a/ui/.env.example
+++ b/ui/.env.example
@@ -1,0 +1,10 @@
+# ABP Vue 前端环境变量示例
+NUXT_AUTHORITY_URL=https://localhost:44312
+NUXT_CLIENT_ID=Abp_Vue
+NUXT_CLIENT_SECRET=CHANGE_ME
+NUXT_SCOPE=openid profile email BilliardHall
+NUXT_REDIRECT_URI=/api/auth/callback/openiddict
+NUXT_POST_LOGOUT_REDIRECT_URI=/api/auth/signout/callback
+NUXT_ORIGIN=https://localhost:3000
+NUXT_SESSION_SECRET=PLEASE_GENERATE_A_RANDOM_BASE64
+NUXT_ABP_API_ENDPOINT=https://localhost:44388/api

--- a/ui/README.md
+++ b/ui/README.md
@@ -1,0 +1,74 @@
+# BilliardHall 前端 (Nuxt + ABP Vue 风格)
+
+## 功能定位
+
+- 作为 ABP 后端 (OpenIddict) 的 SPA / 管理界面入口
+- 使用 OIDC 授权码 + 刷新令牌模式
+
+## 快速开始
+
+```bash
+# 复制环境变量模板
+cp .env.example .env
+# 根据需要修改 ClientSecret / API Endpoint
+# 安装依赖 (建议已全局安装 pnpm)
+pnpm install
+# 启动开发
+pnpm dev
+```
+
+浏览器访问 <https://localhost:3000> （若出现自签名证书警告，可临时信任）。
+
+## 主要环境变量 (.env)
+
+详见根项目 `doc/08_配置管理/Secrets管理.md` 对照表。
+
+| 变量 | 必填 | 说明 |
+|------|------|------|
+| NUXT_AUTHORITY_URL | 是 | OIDC 授权服务器地址 |
+| NUXT_CLIENT_ID | 是 | 必须与后端 OpenIddict 种子一致 |
+| NUXT_CLIENT_SECRET | 视客户端类型 | 机密型客户端需要，公共客户端留空 |
+| NUXT_SCOPE | 是 | 建议: openid profile email BilliardHall |
+| NUXT_ABP_API_ENDPOINT | 是 | 后端 API 根地址 |
+| NUXT_SESSION_SECRET | 是 | 随机 Base64，用于会话/加密用途 |
+
+## 与后端的对应
+
+- OpenIddict 客户端配置在 `OpenIddictDataSeedContributor` 中通过 `OpenIddict:Applications:Abp_Vue:*` 读取
+- 若需修改重定向 URI，对应更新：
+  - `.env` 中 `NUXT_REDIRECT_URI` / `NUXT_POST_LOGOUT_REDIRECT_URI`
+  - 后端配置节 `OpenIddict:Applications:Abp_Vue:RootUrl`
+
+## 生成 API Type (后续可扩展)
+
+> 当前未集成自动代码生成脚本；若接入 swagger 生成，可添加：
+
+```jsonc
+// package.json scripts 片段示例
+"generate:api": "openapi-typescript https://localhost:44388/swagger/v1/swagger.json -o generated/api.d.ts"
+```
+
+## 代码结构（初始最小化）
+
+- `nuxt.config.ts` 运行时公开配置注入
+- `.env.example` 变量模板
+
+后续可扩展：
+
+- 授权拦截插件 / Axios 请求封装
+- 动态菜单与权限指令
+- UI 组件库接入（Element Plus / Naive UI 等）
+
+## 开发建议
+
+- 使用 `pnpm` 保持锁文件一致性
+- 严格 TS，开启 ESLint（已预留脚本）
+- 区分公共与机密客户端：公共客户端不要配置 ClientSecret
+
+## TODO (后续可在 Issue 中跟踪)
+
+- [ ] 接入 OpenId Connect 登录逻辑封装（Composable / Plugin）
+- [ ] 添加统一错误处理与重试机制
+- [ ] API 客户端生成与缓存策略
+- [ ] 前端日志/性能指标上报 OTLP
+- [ ] 生产打包 Dockerfile / Nginx 配置

--- a/ui/nuxt.config.ts
+++ b/ui/nuxt.config.ts
@@ -1,0 +1,16 @@
+// Minimal Nuxt config for ABP Vue integration
+export default defineNuxtConfig({
+  devtools: { enabled: true },
+  typescript: { strict: true },
+  runtimeConfig: {
+    public: {
+      authorityUrl: process.env.NUXT_AUTHORITY_URL,
+      clientId: process.env.NUXT_CLIENT_ID,
+      clientSecret: process.env.NUXT_CLIENT_SECRET,
+      scope: process.env.NUXT_SCOPE,
+      apiEndpoint: process.env.NUXT_ABP_API_ENDPOINT,
+      origin: process.env.NUXT_ORIGIN
+    },
+    sessionSecret: process.env.NUXT_SESSION_SECRET
+  }
+});

--- a/ui/package.json
+++ b/ui/package.json
@@ -1,0 +1,25 @@
+{
+  "name": "billiardhall-ui",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "dev": "nuxt dev",
+    "build": "nuxt build",
+    "preview": "nuxt preview",
+    "generate": "nuxt generate",
+    "lint": "eslint .",
+    "lint:fix": "eslint . --fix"
+  },
+  "dependencies": {
+    "nuxt": "^3.12.0",
+    "@abp/axios": "^8.0.0",
+    "@abp/core": "^8.0.0"
+  },
+  "devDependencies": {
+    "eslint": "^9.9.0",
+    "@typescript-eslint/parser": "^8.0.0",
+    "@typescript-eslint/eslint-plugin": "^8.0.0",
+    "typescript": "^5.5.4"
+  }
+}


### PR DESCRIPTION
## 前端与 OIDC 集成增量 (依赖 #54)

此 PR 构建在基础设施 PR #54 之上（需其先合并），提供前端初始接入与 OIDC 客户端支持：

### 主要内容
1. 新增 `ui/` 目录（Nuxt 3 脚手架）
   - `package.json` / 脚本：dev/build/lint
   - `nuxt.config.ts` 注入公开 runtimeConfig (NUXT_* 环境变量)
   - `.env.example` 全量变量模板
   - `README.md` 使用说明 / 环境变量 / TODO 列表
2. OpenIddict 数据种子新增 `Abp_Vue` 客户端：
   - 授权码 + Refresh Token 流程
   - Public / Confidential 动态判定（基于是否配置 ClientSecret）
   - 统一重定向：`/api/auth/callback/openiddict` & `/api/auth/signout/callback`
3. 开发环境 CORS：`https://localhost:3000` 加入 `App:CorsOrigins`
4. `Secrets管理.md` 扩展前端环境变量章节（NUXT_*）

### 不包含的内容（后续 PR）
- 前端实际 OIDC 登录逻辑（PKCE 流程封装）
- Token 刷新 / 失效恢复机制
- API 自动类型生成脚本 (`generate:api` 占位暂未接入依赖)
- 前端错误监控 / 性能埋点 / OTLP 上报

### 验证建议
1. 合并 #54 后拉取本分支
2. 设置后端配置节：
   ```jsonc
   // appsettings.Development.json 示例（可在 user secrets）
   "OpenIddict": {
     "Applications": {
       "Abp_Vue": {
         "ClientId": "Abp_Vue",
         "ClientSecret": "DEV_ONLY_CHANGE_ME", // 公共客户端可留空
         "RootUrl": "https://localhost:3000"
       }
     }
   }
   ```
3. 运行 AppHost（确保 Postgres & Migrator 完成）
4. 前端：复制 `.env.example` → `.env`，填入 `NUXT_SESSION_SECRET`
5. `pnpm install && pnpm dev` 访问 `https://localhost:3000`
6. 浏览器 DevTools 观察跨域预检成功 (OPTIONS 200) 与 runtimeConfig 注入

### 目录速览
```
ui/
  package.json
  nuxt.config.ts
  .env.example
  README.md
```

### 风险与注意事项
| 项目 | 风险 | 缓解 |
|------|------|------|
| OIDC 客户端重定向路径固定 | 前端未来自定义路径需同步后端配置 | README 标注 + 配置节说明 |
| ClientSecret 暂存 .env | 生产应改为部署时注入（非提交） | Secrets 文档已说明 |
| CORS 单一来源 | 部署阶段需追加生产域名 | 后续部署 PR 引入环境化模板 |

### 后续计划 (建议拆分 Issue)
1. OIDC 登录 + PKCE + Refresh Token 自动续期
2. Axios 封装 + API 类型生成（openapi-typescript）
3. 统一错误处理与 401/403 重登陆策略
4. 前端日志 / 性能指标 → OTLP Collector
5. Dockerfile & Nginx 部署配置

### 依赖说明
本 PR 不改动已在 #54 中的基础设施文件；冲突风险低。请先合并 #54，再合并本 PR。

---
如需改为直接指向 `main`（串行合并模式）请评论告知。