### PR TITLE
docs(changelog): add initial changelog (0.1.0 baseline)

### DIFF
--- a/doc/12_版本与变更管理/变更日志.md
+++ b/doc/12_版本与变更管理/变更日志.md
@@ -1,3 +1,39 @@
 # 变更日志
 
-TODO: CHANGELOG 模板与示例。
+本文件遵循 [Keep a Changelog](https://keepachangelog.com/zh-CN/1.1.0/) 与 [语义化版本](https://semver.org/lang/zh-CN/)。
+
+## [Unreleased]
+
+（预留：后续合并尚未发布的改动暂存区，发布时移动到新版本号下）
+
+## [0.1.0] - 2025-10-01
+
+首个可运行的基础设施与前端认证集成基线版本（内部预览 / POC 性质）。
+
+### Added
+
+- 引入基础 changelog 结构 & 版本策略说明。
+
+### Notes
+
+- 历史提交尚未逐条回溯，可在后续版本根据需要补充。
+
+---
+
+### 版本策略说明
+
+- 0.x 阶段：结构快速演进，可能出现破坏性调整；稳定后提升至 1.0.0。
+- “Unreleased” 用作待发布累积区；发版时复制条目到新版本并清空。
+
+### 分类约定（快速参考）
+
+- Added: 新增的功能或文件结构
+- Changed: 行为变化或接口调整
+- Deprecated: 标记将要移除的功能
+- Removed: 已移除的功能
+- Fixed: 缺陷修复
+- Security: 安全相关改进
+- Documentation: 文档层更新
+
+[Unreleased]: https://github.com/douhuaa/Zss.BilliardHall/compare/v0.1.0...HEAD
+[0.1.0]: https://github.com/douhuaa/Zss.BilliardHall/tree/v0.1.0


### PR DESCRIPTION
### 背景
项目先前缺少标准化变更日志文件，无法在后续演进中清晰追踪差异。本 PR 初始化符合 Keep a Changelog 与 语义化版本 的结构，为后续版本管理打基础。

### 变更内容
- 新增 `doc/12_版本与变更管理/变更日志.md` 采用 Keep a Changelog 模板
- 创建 `0.1.0` 基线版本（仅占位说明，不回溯历史全部细节）
- 预留 `[Unreleased]` 段落供未来 PR 增量条目累积
- 提供分类约定与版本策略说明

### 不包含
- 未创建 Git tag（待合并后可执行 `git tag v0.1.0 && git push origin v0.1.0`）
- 未回溯所有历史提交逐项列出（可按需补齐）

### 验证
- Markdown 结构手动校验（标题与列表格式符合常规 lint 要求）
- 文件位置符合既有 `12_版本与变更管理` 目录

### 后续建议
1. 合并后创建 `v0.1.0` tag，形成基线比较锚点
2. 约定：新的功能 / 安全 / 文档修改在 PR 中同步更新 `[Unreleased]` 小节
3. 扩展 CI：可增加简单校验，若代码变更但 changelog 未更新则提示 Review
4. 当准备发布新版本（例如 0.2.0）时：
   - 将 `[Unreleased]` 梳理内容复制到 `## [0.2.0] - YYYY-MM-DD`
   - 清空/保留一个新的 `[Unreleased]` 占位

### 回滚策略
Revert 此 PR 即可（不影响代码逻辑）。

---
如需同步生成英文版 `CHANGELOG.en.md`，可在本 PR 审阅后附加提交。