### PR TITLE
docs(style-guide): 增补时间/取消令牌/异常编码/EF性能/Nullable/测试规范扩展章节

### DIFF
--- a/doc/06_开发规范/代码风格.md
+++ b/doc/06_开发规范/代码风格.md
@@ -818,6 +818,70 @@ public string FormatSessionInfo(TableSession session)
 
 快速参考：`feat` 新功能 / `fix` 缺陷 / `docs` 文档 / `refactor` 重构（无功能变化）/ `perf` 性能 / `test` 测试 / `build` 构建依赖 / `chore` 杂项 / `ci` 流水线 / `security` 安全修复。
 
+## 扩展规范补充
+
+> 以下为在初版基础上的增强准则，补足运行期一致性、可维护性与跨层协作的细节。后续若正式拆分将独立成子章节。
+
+### 1. 时间与时区策略
+
+- 持久化一律使用 UTC：`DateTime.UtcNow`，数据库列统一存 UTC；避免 `DateTime.Now`（仅限展示/日志场景）。
+- 需要本地化展示在前端或 API DTO 层转换（不在 Domain 内做时区换算）。
+- 若需要语义明确，优先考虑 `DateTimeOffset`（例如支付回调带时区来源）。
+- 禁止混用：同一聚合根字段中不能部分使用 UTC / 部分本地时间。
+
+### 2. CancellationToken 使用
+
+- 所有可能进行 IO / 需要可取消的公开异步方法签名：`Task<T> MethodAsync(..., CancellationToken cancellationToken = default)`。
+- 仅在链路根（Controller/ApplicationService）可选择忽略 token；内部调用必须向下传递。
+- 不在 Domain 纯计算方法中引入 token 参数（除非计算可中断且耗时显著）。
+
+### 3. 业务异常编码规范
+
+- 使用 `BusinessException` 时设置 Code：格式 `<Area>:<Key>`，示例：`Billing:TableUnavailable`、`Auth:PermissionDenied`。
+- 统一集中枚举（建议新增 `Domain.Shared/ErrorCodes.cs`）以便前端基于 code 分类提示。
+- 不把面向用户的自然语言硬编码在多个抛出点：内部保持 Code + 精简技术信息，UI 层/本地化资源做友好翻译。
+
+示例：
+```csharp
+public static class ErrorCodes
+{
+    public const string TableUnavailable = "Billing:TableUnavailable";
+}
+
+throw new BusinessException(ErrorCodes.TableUnavailable)
+    .WithData("TableId", tableId)
+    .WithData("Status", table.Status);
+```
+
+### 4. EF Core 查询与性能最小指引（详情见分层与数据规范）
+
+- 只读查询：使用 `AsNoTracking()`。
+- 避免 N+1：用投影（`Select(new Dto { ... })`）而不是盲目 `Include` 大图。
+- 分页：先排序再分页；大页（>1000）考虑游标或时间窗口策略。
+- 批量存在性校验用 `AnyAsync()` 而不是 `Count()`。
+- 聚合查询避免在内存中二次筛选（尽量让数据库执行）。
+
+### 5. Nullable 与空值处理
+
+- 项目启用 `<Nullable>enable</Nullable>`（若未启用需在解决方案 props 中补充）。
+- 禁止使用 `!` 运算符消除警告作为常态手段，必须能证明逻辑不可能为空（必要时添加守卫 + 注释解释）。
+- DTO 输出字段允许可空（与真实存在性对应），Domain 结构若出现可空需确认业务语义（是否可以通过值对象替代）。
+
+### 6. 测试命名与结构
+
+- 单元测试命名：`MethodName_条件_期望()`，英文可用 `Method_State_Result`。
+- Arrange / Act / Assert 清晰分段（可用空行或注释标识）。
+- 不在单元测试中访问真实外部（HTTP、Redis、MQ）——使用内存或 Stub。
+- 针对新增公共业务规则：至少 1 个“正常路径” + 1 个“异常/边界”用例。
+
+### 7. 日志字段占位符统一（补充）
+
+- 标识类：`{UserId}` `{TableId}` `{SessionId}` `{CorrelationId}`。
+- 金额相关统一使用十进制，不直接输出内部浮点（格式化时使用 `:F2`）。
+- 避免日志中直接输出敏感内容（Token、手机号完整值等）。
+
+---
+
 ## 附录与相关文档
 
 ### 同级文档


### PR DESCRIPTION
变更摘要：

新增“扩展规范补充”章节，内容涵盖：
- 时间与时区统一策略（持久化统一使用 UTC，展示层本地化）
- CancellationToken 传递要求（所有公开异步方法优先支持取消）
- 业务异常编码规范（统一 Code 格式 <Area>:<Key>，集中枚举）
- EF Core 查询性能最小指引（AsNoTracking、投影、分页、聚合优化）
- Nullable 策略（启用 <Nullable>enable</Nullable>，禁止滥用 !）
= 测试命名与结构（Method_条件_期望，Arrange/Act/Assert 分段）
- 日志字段占位符统一（如 {UserId}、金额格式化等）

插入 ErrorCodes 示例代码片段，便于后续落地
动机：

-补足原风格文档对运行期一致性、协作边界的缺失
-为后续质量基线（异常可观测性、查询优化、测试覆盖）提供可执行清单

审查要点：

- 异常 Code 方案是否需与现有 Domain 已有常量对齐
- 是否需要单独拆分为 6.2.x 子文档（视后续演进）
- 是否与已有“分层约束”、“日志规范”存在冲突条款

兼容性影响：

-仅文档，不修改生产代码
-对将来代码评审标准增加更严格检查点（正向影响）

后续工作建议：

-拆分为独立章节（如 6.1.x 补充）
-与监控/告警策略文档挂钩（异常 Code → 监控维度）

测试说明：

-文档扩展，Tests: N/A