### PR TITLE
docs(editorconfig): 增强 C# 风格与诊断规则(IDE0063/IDE0058/IDE0090)

### DIFF
--- a/src/Zss.BilliardHall/.editorconfig
+++ b/src/Zss.BilliardHall/.editorconfig
@@ -1,2 +1,105 @@
 [*.csproj]
 indent_size = 2
+
+#############################################
+# C# Code Style (同步文档 6.1 代码风格摘要)  #
+#############################################
+
+root = true
+
+[*]
+charset = utf-8
+insert_final_newline = true
+trim_trailing_whitespace = true
+
+[*.cs]
+indent_style = space
+indent_size = 4
+end_of_line = crlf
+
+# Using 排序
+dotnet_sort_system_directives_first = true
+dotnet_separate_import_directive_groups = false
+
+# this. 前缀
+dotnet_style_qualification_for_field = false:warning
+dotnet_style_qualification_for_property = false:warning
+dotnet_style_qualification_for_method = false:warning
+dotnet_style_qualification_for_event = false:warning
+
+# 预定义类型
+dotnet_style_predefined_type_for_locals_parameters_members = true:warning
+dotnet_style_predefined_type_for_member_access = true:warning
+
+# 括号清晰度
+dotnet_style_parentheses_in_arithmetic_binary_operators = always_for_clarity:suggestion
+dotnet_style_parentheses_in_relational_binary_operators = always_for_clarity:suggestion
+
+# 修饰符 & readonly
+dotnet_style_require_accessibility_modifiers = always:warning
+dotnet_style_readonly_field = true:warning
+
+# 初始化器 & 空值
+dotnet_style_object_initializer = true:suggestion
+dotnet_style_collection_initializer = true:suggestion
+dotnet_style_null_propagation = true:suggestion
+dotnet_style_coalesce_expression = true:suggestion
+dotnet_style_prefer_is_null_check_over_reference_equality_method = true:suggestion
+
+# var 规则
+csharp_style_var_for_built_in_types = false:warning
+csharp_style_var_when_type_is_apparent = true:suggestion
+csharp_style_var_elsewhere = false:suggestion
+
+# 表达式成员
+csharp_style_expression_bodied_methods = when_on_single_line:suggestion
+csharp_style_expression_bodied_constructors = false:warning
+csharp_style_expression_bodied_operators = when_on_single_line:suggestion
+csharp_style_expression_bodied_properties = when_on_single_line:suggestion
+csharp_style_expression_bodied_indexers = when_on_single_line:suggestion
+csharp_style_expression_bodied_accessors = when_on_single_line:suggestion
+
+# 模式匹配
+csharp_style_pattern_matching_over_is_with_cast_check = true:suggestion
+csharp_style_pattern_matching_over_as_with_null_check = true:suggestion
+
+# 其它表达式层
+csharp_style_throw_expression = true:suggestion
+csharp_style_conditional_delegate_call = true:suggestion
+csharp_preferred_modifier_order = public,private,protected,internal,static,extern,new,virtual,abstract,sealed,override,readonly,unsafe,volatile,async:suggestion
+csharp_prefer_braces = true:warning
+csharp_style_deconstructed_variable_declaration = true:suggestion
+csharp_prefer_simple_using_statement = true:suggestion
+csharp_style_pattern_local_over_anonymous_function = true:suggestion
+
+# New line & 空格（关键参数选）
+csharp_new_line_before_open_brace = all
+csharp_new_line_between_query_expression_clauses = true
+csharp_space_after_keywords_in_control_flow_statements = true
+csharp_space_around_binary_operators = before_and_after
+
+# 命名
+dotnet_naming_rule.interface_should_be_prefixed_with_i.severity = warning
+dotnet_naming_rule.interface_should_be_prefixed_with_i.symbols = interface
+dotnet_naming_rule.interface_should_be_prefixed_with_i.style = prefix_interface_with_i
+dotnet_naming_symbols.interface.applicable_kinds = interface
+dotnet_naming_style.prefix_interface_with_i.capitalization = pascal_case
+dotnet_naming_style.prefix_interface_with_i.required_prefix = I
+
+#############################################
+# Additional Diagnostics (PR3 增强)        #
+#############################################
+# IDE0063: 使用简单 using
+dotnet_diagnostic.IDE0063.severity = suggestion
+# IDE0058: 丢弃的返回值（提高潜在错误发现）
+dotnet_diagnostic.IDE0058.severity = warning
+# IDE0090: 简化 new 表达式 new()
+dotnet_diagnostic.IDE0090.severity = suggestion
+
+#############################################
+# Build Integration                           #
+#############################################
+dotnet_analyzer_diagnostic.category-Style.severity = warning
+dotnet_analyzer_diagnostic.category-Reliability.severity = warning
+dotnet_analyzer_diagnostic.category-Performance.severity = warning
+dotnet_analyzer_diagnostic.category-Design.severity = warning


### PR DESCRIPTION
变更摘要：

1. 扩展仓库根 [.editorconfig](vscode-file://vscode-app/c:/Users/xmhbhy/AppData/Local/Programs/Microsoft%20VS%20Code/resources/app/out/vs/code/electron-browser/workbench/workbench.html)，由原仅 csproj 缩进配置升级为完整风格基线
1. 对齐 6.1 代码风格文档的核心规则（缩进/括号/var/初始化器/命名/空格/换行）
1.新增诊断：
    - IDE0063: 建议使用简化 using
    - IDE0058: 检测被忽略的返回值（潜在逻辑遗漏）
    - IDE0090: 简化对象创建为 new()
1. 设置各 Analyzer 分类 (Style/Reliability/Performance/Design) 严重级别为 warning，避免一次性阻断构建
1. 保留未来扩展空间（未直接启用 TreatWarningsAsErrors）

动机：

- 将“文档规范”左移到编译期，减少人工 Code Review 重复工作
- 捕获潜在遗漏（IDE0058）并推动更现代语法一致性
- 为后续分阶段清理告警建立统一基线

审查要点：

-是否与现有解决方案级 props/MSBuild 警告策略冲突
-是否需要在后续 PR 中开启 <EnforceCodeStyleInBuild>true</EnforceCodeStyleInBuild>
-是否需要对其中部分 suggestion 级别降级（例如在当前告警基数较大时）

兼容性影响：

-不改变业务逻辑
-初次合并后本地/CI 可能出现新增的 warning 列表
-不会导致构建失败（除非团队已有 TreatWarningsAsErrors 全局开启）

后续建议：

-新建追踪 Issue 规划“按目录 / 按规则”分批清理告警
-结合 Directory.Build.props 启用 <Nullable>enable</Nullable>（若未启用）
-评估引入自定义命名规则（DTO / Input / Output 后缀等）
-后续可加入业务层命名特殊规则（如 聚合根 结尾不使用 Entity）

测试说明：

- 纯配置，无逻辑运行路径
- Tests: N/A